### PR TITLE
Slightly modified how a custom formatItemTimeFunc is invoked.

### DIFF
--- a/_RendererMixin.js
+++ b/_RendererMixin.js
@@ -216,7 +216,7 @@ define(["dojo/_base/declare", "dojo/_base/lang", "dojo/dom-style", "dojo/dom-cla
 			if(this.owner){
 				var f = this.owner.get("formatItemTimeFunc");
                 if(f != null && typeof f === "function"){
-                    return f.call(this.owner, d, rd);
+                    return f(d, rd);
                 }
 			}
 			return rd.dateLocaleModule.format(d, {selector: 'time'});


### PR DESCRIPTION
Whenever a formatItemTimeFunc was being set, it was not being properly executed due to the following error "Uncaught TypeError: Property 'formatItemTimeFunc' of object [object Object] is not a function". Added type check and changing invocation method seems to solve the issue.
