### PR TITLE
Fix for monthly calendar view not resizing properly

### DIFF
--- a/MatrixView.js
+++ b/MatrixView.js
@@ -976,7 +976,10 @@ function(
 
 			if(rd.sheetHeight != this.itemContainer.offsetHeight){
 				// refresh values
-				rd.sheetHeight = this.itemContainer.offsetHeight;
+				if (rd.sheetHeight > this.itemContainer.offsetHeight) {
+					rd.sheetHeight = this.itemContainer.offsetHeight;
+				}
+
 				var expRow = this.getExpandedRowIndex();
 				if(expRow == -1){
 					this._computeRowsHeight();


### PR DESCRIPTION
Right now if browser window is less than full screen and you maximise it by double click on title bar (windows) or click on '+' (osx) and minimise it again, calendar will be resized incorrectly and part of it will be cut off in the browser. PR contains simple fix for this particular situation. Tested for different use cases and I'm fairly certain that it doesn't break any existing functionality.

Screen showing the issue:
![untitled](https://f.cloud.github.com/assets/950505/2355783/ab63e964-a5e0-11e3-8ce3-9eceb048d498.jpg)
