### PR TITLE
fixes #18685, prevent parent table styles from breaking calendar styles

### DIFF
--- a/themes/claro/ColumnView.less
+++ b/themes/claro/ColumnView.less
@@ -1,6 +1,6 @@
 @import "ColumnViewCommon.less";
 
-.claro .dojoxCalendarColumnView {	
+.claro .dojoxCalendarColumnView {
 	cursor: default;
 	-webkit-user-select: none;
 
@@ -25,14 +25,14 @@
 		border-bottom: @outer-border;
 		.border-box;
 	}
-	
+
 	.dojoxCalendarGrid {
 		position: absolute;
 		left: @row-header-width;
 		right: 0;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarGrid.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
@@ -44,13 +44,13 @@
 		position: relative;
 		margin: 0;
 		padding: 0;
-		
+
 	 	td {
-			border-top: dotted 1px @outer-border;	
+			border-top: dotted 1px @outer-border;
 			border-right: @inner-border;
 			.border-box;
 		}
-	
+
 		tr:first-child td	{
 			border-top: 1px solid transparent;
 		}
@@ -58,31 +58,31 @@
 		.dojoxCalendarToday {
 			background-color: @today-color;
 		}
-		
+
 		tr td.last-child	{
 			border-right: @outer-border;
 		}
-		
+
 		.tr:first-child td.dojoxCalendarToday	{
 			border-top: 1px solid @today-color;
 		}
-		
+
 		.dojoxCalendarWeekend {
 			background-color: @week-end-color;
 		}
-		
+
 		tr:first-child td.dojoxCalendarWeekend	{
 			border-top: 1px solid @week-end-color;
-		}	
+		}
 	}
 
-	 
+
 	td.hour {
 		border-top: @hour-stroke;
 	}
 
 	td.halfhour{
-		border-top: @half-hour-stroke;	
+		border-top: @half-hour-stroke;
 	}
 
 	td.quarterhour{
@@ -107,12 +107,24 @@
 		right: 0;
 		cursor: default;
 		overflow: hidden;
+
+		table {
+			background-color: transparent;
+
+			tr {
+				background-color: transparent;
+
+				td {
+					background-color: transparent;
+				}
+			}
+		}
 	}
-	
+
 	.dojoxCalendarContainer.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-	
+
 	.dojoxCalendarContainerTable {
 		border-collapse: collapse;
 		table-layout: fixed;
@@ -120,7 +132,7 @@
 		position: relative;
 		margin: 0;
 		padding: 0;
-	
+
 		td {
 			height: 100%;
 			padding: 0;
@@ -128,39 +140,39 @@
 			border-right: 1px solid transparent;
 		}
 	}
-	
+
 	.dojoxCalendarContainerColumn {
 		position: relative;
-		width:100%;		
+		width:100%;
 	}
-	
+
 	.dojoxCalendarSubContainerColumn {
-		position: absolute;		
+		position: absolute;
 		top: 0;
 		.border-box;
-		height:100%;	
+		height:100%;
 	}
-	
+
 	.dojoxCalendarEventContainerColumn {
-		position: absolute;		
+		position: absolute;
 		height: 100%;
 		left:0;
 		top:0;
 		right:0;
 		margin-left: 1px;
-		margin-right: 5px;		
+		margin-right: 5px;
 	}
-	
+
 	.dojoxCalendarDecorationContainerColumn {
-		position: absolute;		
+		position: absolute;
 		height: 100%;
 		left:0;
 		top:0;
-		right:0;	
+		right:0;
 	}
-	
+
 	.dojoxCalendarSubContainerColumn.subColumn {
-		border-right: @sub-column-border;		
+		border-right: @sub-column-border;
 	}
 
 	.dojoxCalendarEventContainer {
@@ -174,21 +186,21 @@
 		height: @column-header-height - 1px;
 		left: 0;
 		width: @row-header-width - 2px;
-		top: 0;	
+		top: 0;
 		border-left: @outer-border;
 		border-top: @outer-border;
-		border-right: @outer-border;	
-	
+		border-right: @outer-border;
+
 		table {
 			position:relative;
 			width:100%;
-			height:100%;	
+			height:100%;
 		}
-		
+
 		table td {
 			text-align: center;
 			vertical-align: middle;
-			border-bottom: @outer-border;	
+			border-bottom: @outer-border;
 			color: @label-color;
 			.header-background;
 		}
@@ -196,28 +208,28 @@
 
 	.dojoxCalendarColumnHeader {
 		position: absolute;
-		height: @column-header-height;	 
+		height: @column-header-height;
 		left: @row-header-width;
 		right: 0;
 		top: 0;
 		cursor: default;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarColumnHeader.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-	
+
 	.dojoxCalendarColumnHeaderTable {
 		border-collapse: collapse;
 		table-layout: fixed;
 		position: relative;
 		margin: 0;
-		padding: 0;			
+		padding: 0;
 		width: 100%;
-		height: 100%;	
+		height: 100%;
 
-		td {	
+		td {
 			overflow:hidden;
 			white-space: nowrap;
 			vertical-align: middle;
@@ -230,30 +242,30 @@
 			color: @label-color;
 			.transition-duration(0.2s);
 		}
-		
-		td.last-child {	
-			border-right: @outer-border;	
+
+		td.last-child {
+			border-right: @outer-border;
 		}
-		
+
 		.dojoxCalendarToday {
 			font-weight: bold;
 			color: @today-label-color;
 		}
-		
+
 		.dojoxCalendarWeekend {
 			color: @week-end-label-color;
 		}
-		
-		td.Hover{	
-			cursor: pointer;		
+
+		td.Hover{
+			cursor: pointer;
 			.header-hover-background;
 		}
-		
-		td.Active{	
+
+		td.Active{
 			.header-active-background;
 		}
 	}
-	
+
 	.dojoxCalendarSubHeader {
 		position: absolute;
 		left: 0;
@@ -265,7 +277,7 @@
 		box-sizing: border-box;
 		display: none;
 	}
-	
+
 	.dojoxCalendarSubColumnHeader {
 		position: absolute;
 		height: @sub-column-header-height;
@@ -275,11 +287,11 @@
 		cursor: default;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarSubColumnHeader.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-		
+
 	.dojoxCalendarSubColumnHeaderTable {
 		border-collapse: collapse;
 		table-layout: fixed;
@@ -288,55 +300,55 @@
 		padding: 0;
 		width: 100%;
 		height: 100%;
-		
+
 		td {
 			overflow: hidden;
 			white-space: nowrap;
 			vertical-align: middle;
-			text-align: center;  
-			border-right: @inner-border; 
+			text-align: center;
+			border-right: @inner-border;
 			border-top: @outer-border;
 			-moz-user-select: none;
 			-webkit-user-select: none;
 			khtml-user-select: none;
 			user-select: none;
-			color: #000000;  
+			color: #000000;
 		}
 		td.last-child {
 			border-right: @outer-border;
 		}
-		td.dojoxCalendarToday { 
+		td.dojoxCalendarToday {
 			background-color: @today-color;
 		}
 		td.dojoxCalendarWeekend {
 			background-color: @week-end-color;
-		}					
+		}
 	}
-	
-	.dojoxCalendarSubHeaderContainer {			
+
+	.dojoxCalendarSubHeaderContainer {
 		position: relative;
-		width:100%;		
+		width:100%;
 		height: @sub-column-header-height - 2px;
-	}	
-	
+	}
+
 	.dojoxCalendarSubHeaderCell {
-		position: absolute;		
+		position: absolute;
 		top: 0;
 		.border-box;
-		height:100%;	
+		height:100%;
 		overflow: hidden;
 		text-overflow: ellipsis;
-	}	
-	
+	}
+
 	.dojoxCalendarSubHeaderCell.subColumn {
-		border-right: @sub-column-border;		
-	}	
-	
+		border-right: @sub-column-border;
+	}
+
 	.dojoxCalendarSubHeaderLabel {
 		font-size: 0.9em;
 		color: #555;
 	}
-	
+
 	.dojoxCalendarSubRowHeader {
 		position: absolute;
 		height: @sub-column-header-height;
@@ -350,11 +362,11 @@
 			position: relative;
 			width: 100%;
 			height: 100%;
-			
+
 			td {
 				border-top: @outer-border;
-				background-color: #efefef;  
-			}			
+				background-color: #efefef;
+			}
 		}
 	}
 
@@ -374,9 +386,9 @@
 		z-index: 10;
 	}
 
-	.dojoxCalendarRowHeaderLabel{	
-		right: 4px;		
-		position: absolute;	
+	.dojoxCalendarRowHeaderLabel{
+		right: 4px;
+		position: absolute;
 	}
 
 	.dojoxCalendarRowHeaderTable {
@@ -387,35 +399,35 @@
 		padding: 0;
 		width: 100%;
 		height: 100%;
-	
+
 		td.dummy{
 			border-top: 1px solid @row-color;
 		}
-		
+
 		td {
 			background-color: @row-color;
 			color: @label-color;
 			.border-box;
 		}
-		
+
 		tr:first-child td	{
 			border-top: 1px solid @row-color;
 		}
 	}
-	
+
 	.dojoxCalendarDecoration {
 		position:absolute;
 		background-color: rgb(167, 233, 68);
 		.opacity(20);
 	}
- 
+
 	.dojoxCalendarEvent {
-		position: absolute;	
+		position: absolute;
 		text-align: left;
 		color: #FFF;
 		cursor: default;
 		overflow: hidden;
-	
+
 		.bg {
 			position: absolute;
 			left: 0;
@@ -428,10 +440,10 @@
 			background-color: @event-bg-color;
 			.opacity(90);
 		}
-				
+
 		.endTime {
-			position: absolute;		
-			font-weight: bold;	
+			position: absolute;
+			font-weight: bold;
 			bottom:3px;
 			left: 6px;
 			white-space:nowrap;
@@ -457,7 +469,7 @@
 			top:0;
 			width:100%;
 			bottom:0;
-			cursor:move;	
+			cursor:move;
 		}
 
 		.resizeStartHandle {
@@ -465,7 +477,7 @@
 			top:0;
 			width:100%;
 			height:10px;
-			cursor:n-resize;	
+			cursor:n-resize;
 		}
 
 		.resizeEndHandle {
@@ -473,7 +485,7 @@
 			bottom:0;
 			width:100%;
 			height:10px;
-			cursor:n-resize;	
+			cursor:n-resize;
 		}
 
 		dl {
@@ -488,7 +500,7 @@
 	}
 
 	.dojoxCalendarEvent.Hovered .bg {
-		background-color: @event-hovered-bg-color;	
+		background-color: @event-hovered-bg-color;
 	}
 
 	.dojoxCalendarEvent.Selected .bg {
@@ -503,10 +515,10 @@
 	.dojoxCalendarEvent.Focused .bg {
 		border: @event-border-focused;
 	}
-	
+
 	.dojoxCalendarEvent .startTime {
-		.event-header;	
-		background-color: @event-header-bg-color;	
+		.event-header;
+		background-color: @event-header-bg-color;
 		.top-left-right-border(@event-border);
 	}
 
@@ -534,23 +546,23 @@
 		overflow-y: scroll;
 		overflow-x: hidden;
 	}
-	
+
 	.dojoxCalendarHScrollBar {
-		position: absolute;		
+		position: absolute;
 		bottom: 0;
-		left: @row-header-width;		
+		left: @row-header-width;
 		overflow-x: scroll;
 		overflow-y: hidden;
 	}
 
-	.dojoxCalendarMatrixView {	
+	.dojoxCalendarMatrixView {
 		position: absolute;
 		left: 0;
 		right: 0;
 		top: @column-header-height;
-		height: @secondary-sheet-height;		
+		height: @secondary-sheet-height;
 
-		.dojoxCalendarGrid {	
+		.dojoxCalendarGrid {
 			position: absolute;
 			left: @row-header-width;
 			right: 0;
@@ -558,8 +570,8 @@
 			bottom: 0;
 			.border-box;
 		}
-		
-		.dojoxCalendarContainer {	
+
+		.dojoxCalendarContainer {
 			position: absolute;
 			top: 0;
 			left: @row-header-width;
@@ -567,40 +579,40 @@
 			bottom: 0;
 			cursor: default;
 		}
-		
+
 		.dojoxCalendarRowHeader {
 			position: absolute;
-			left: 0;				
+			left: 0;
 			top: 0;
 			width: @row-header-width;
 			bottom: 0;
-			
+
 			border-right: none;
 			border-left: none;
 			.border-box;
 		}
-		
+
 		.dojoxCalendarGridTable{
-			
+
 			td {
 				text-align: right;
-				vertical-align: top;	
+				vertical-align: top;
 				border-top: @inner-border;
 				border-bottom: @inner-border;
 				border-right: @inner-border;
 				.border-box;
 			}
-			
+
 			tr.last-child td	{
 				border-bottom: @outer-border;
 			}
-			
+
 			td.last-child	{
 				border-right: @outer-border;
 			}
-			
+
 		}
-		
+
 		.dojoxCalendarRowHeaderTable td {
 			border-top: @inner-border;
 			border-left: @outer-border;
@@ -608,38 +620,38 @@
 			border-bottom: @outer-border;
 			background-color: @row-color;
 		}
-		
+
 		.dojoxCalendarEvent {
 			.handle {
 				.glass-view;
 				position: absolute;
 				width:5px;
 				height:100%;
-				cursor:e-resize;	
+				cursor:e-resize;
 			}
-			
+
 			.moveHandle {
 				left:0;
 				top:0;
 				width:100%;
-				cursor:move;	
+				cursor:move;
 			}
 
 			.resizeEndHandle {
 				right:0px;
 			}
-			
+
 			.afterIcon {
 				width:auto;
 			}
-			
+
 			.endTime {
-				position: relative;				
+				position: relative;
 				bottom:auto;
 				left: auto;
 			}
 		}
-		
+
 		.dojoxCalendarEvent.dojoxCalendarHorizontal .labels {
 			position: absolute;
 			left: 3px;
@@ -647,11 +659,11 @@
 			bottom: 2px;
 			overflow: hidden;
 		}
-		
+
 		.dojoxCalendarExpand {
 			position: absolute;
 			text-align: center;
-			
+
 			.bg {
 				position: relative;
 				margin-right: 10%;
@@ -663,32 +675,32 @@
 				-moz-border-radius: 5px;
 				-webkit-transition-duration: 0.2s;
 				-moz-transition-duration: 0.2s;
-				transition-duration: 0.2s;			
-			}	
+				transition-duration: 0.2s;
+			}
 		}
-		
+
 		.dojoxCalendarExpand.Up .bg {
 			background-color: @expand-up-color;
 			border: 1px solid @expand-up-color - #555;
 		}
-		
+
 		.dojoxCalendarExpand.Down .bg {
 			background-color: @expand-down-color;
 			border: 1px solid @expand-down-color - #555;
 		}
-		
+
 		.dojoxCalendarEvent div {
 			white-space:nowrap;
 		}
 	}
-	
+
 	.dojoxCalendarTimeIndicator {
 		position: absolute;
 		left:0;
 		height: 2px;
 		width:100%;
-		background-color: red;			
-	}					
+		background-color: red;
+	}
 }
 
 .claro .dojoxCalendarColumnView.subColumns {
@@ -701,8 +713,8 @@
 	}
 	.dojoxCalendarVScrollBar {
 		top: @sheet-top-subcolumns;
-	}	
-		
+	}
+
 }
 
 .claro .dojoxCalendarColumnView.secondarySheet {
@@ -730,4 +742,3 @@
 		top: @sheet-top-subcolumns-secondary-sheet;
 	}
 }
-

--- a/themes/iphone/ColumnView.less
+++ b/themes/iphone/ColumnView.less
@@ -1,6 +1,6 @@
 @import "ColumnViewCommon.less";
 
-.dojoxCalendarColumnView {	
+.dojoxCalendarColumnView {
   cursor: default;
 	-webkit-user-select: none;
 }
@@ -26,7 +26,7 @@
 	border-bottom: @outer-border;
 	.border-box;
 }
-	
+
 .dojoxCalendarColumnView .dojoxCalendarGrid {
 	position: absolute;
 	left: @row-header-width;
@@ -43,7 +43,7 @@
 }
 
 .dojoxCalendarColumnView .dojoxCalendarGridTable td {
-	border-top: dotted 1px #B5BCC7;	
+	border-top: dotted 1px #B5BCC7;
 	border-right: @outer-border;
 	.border-box;
 }
@@ -53,7 +53,7 @@
 }
 
 .dojoxCalendarColumnView td.halfhour{
-	border-top: @half-hour-stroke;	
+	border-top: @half-hour-stroke;
 }
 
 .dojoxCalendarColumnView  td.quarterhour{
@@ -77,6 +77,18 @@
 	left: @row-header-width;
 	right: 0;
 	cursor: default;
+    
+	table {
+		background-color: transparent;
+
+		tr {
+			background-color: transparent;
+
+			td {
+				background-color: transparent;
+			}
+		}
+	}
 }
 
 .dojoxCalendarColumnView .dojoxCalendarContainerTable {
@@ -96,25 +108,25 @@
 
 .dojoxCalendarColumnView .dojoxCalendarContainerColumn {
 	position: relative;
-	width:100%;		
+	width:100%;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarSubContainerColumn {
-	position: absolute;		
+	position: absolute;
 	top: 0;
 	box-sizing: border-box;
-	height:100%;	
+	height:100%;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarEventContainerColumn {
-	position: relative;		
+	position: relative;
 	height:100%;
 	margin-left: 1px;
-	margin-right: 5px;		
+	margin-right: 5px;
 }
 
 .dojoxCalendarColumnView  .dojoxCalendarSubContainerColumn.subColumn {
-	border-right: @sub-column-border;		
+	border-right: @sub-column-border;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarEventContainer {
@@ -128,7 +140,7 @@
 	height: @column-header-height;
 	left: 0;
 	width: @row-header-width;
-	top: 0;	
+	top: 0;
 	text-align: center;
 	.header-background;
 	.border-box;
@@ -137,7 +149,7 @@
 .dojoxCalendarColumnView .dojoxCalendarYearColumnHeader table {
 	position:relative;
 	width:100%;
-	height:100%;	
+	height:100%;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarYearColumnHeader table td {
@@ -148,7 +160,7 @@
 
 .dojoxCalendarColumnView .dojoxCalendarColumnHeader {
 	position: absolute;
-	height: @column-header-height;	 
+	height: @column-header-height;
 	left: @row-header-width;
 	right: 0;
 	top: 0;
@@ -160,12 +172,12 @@
 	table-layout: fixed;
 	position: relative;
 	margin: 0;
-	padding: 0;			
+	padding: 0;
 	width: 100%;
-	height: 100%;	
+	height: 100%;
 }
 
-.dojoxCalendarColumnView .dojoxCalendarColumnHeaderTable td {	
+.dojoxCalendarColumnView .dojoxCalendarColumnHeaderTable td {
 	overflow:hidden;
 	white-space: nowrap;
 	vertical-align: middle;
@@ -179,8 +191,8 @@
 	.transition-duration(0.2s);
 }
 
-/* 
- * The dojoxCalendarToday & dojoxCalendarWeekend classes is added by the 
+/*
+ * The dojoxCalendarToday & dojoxCalendarWeekend classes is added by the
  * ColumnView.styleColumnHeaderCell method that can be subclassed to add/remove css classes
  */
 .dojoxCalendarColumnView .dojoxCalendarColumnHeaderTable .dojoxCalendarToday {
@@ -203,9 +215,9 @@
 	z-index: 10;
 }
 
-.dojoxCalendarColumnView .dojoxCalendarRowHeaderLabel{	
-	right: 4px;		
-	position: absolute;	
+.dojoxCalendarColumnView .dojoxCalendarRowHeaderLabel{
+	right: 4px;
+	position: absolute;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarRowHeaderTable {
@@ -218,12 +230,12 @@
 	height: 100%;
 }
 
-/* 
+/*
  * The ColumnView.styleRowHeaderCell method that can be subclassed to add/remove css classes per hour.
  */
-.dojoxCalendarColumnView .dojoxCalendarRowHeaderTable td {	
-	vertical-align: top;			
-	text-align: right;	
+.dojoxCalendarColumnView .dojoxCalendarRowHeaderTable td {
+	vertical-align: top;
+	text-align: right;
 	color: @header-label-color;
 	border-top: 1px solid transparent;
 }
@@ -236,9 +248,9 @@
  	padding-top: 2px;
 	padding-right: 4px;
 }
- 
+
 .dojoxCalendarColumnView .dojoxCalendarEvent {
-	position: absolute;	
+	position: absolute;
 	text-align: left;
 	color: #FFF;
 	cursor: default;
@@ -251,14 +263,14 @@
 	top: 0;
 	bottom: 0;
 	z-index: -1;
-	border: 1px solid #260000;	
+	border: 1px solid #260000;
 	.rounded-corners;
 	background-color: #9F0000;
 	.opacity(90);
 }
 
 .dojoxCalendarColumnView .dojoxCalendarEvent.Hovered .bg {
-	background-color: #CC0000;	
+	background-color: #CC0000;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarEvent.Selected .bg {
@@ -282,8 +294,8 @@
 }
 
 .dojoxCalendarColumnView .dojoxCalendarEvent .endTime {
-	position: absolute;		
-	font-weight: bold;	
+	position: absolute;
+	font-weight: bold;
 	bottom:10px;
 	left: 3px;
 }
@@ -306,16 +318,16 @@
 .dojoxCalendarEvent .resizeHandle div {
 	position:absolute;
 	left: 3px;
-	right: 3px;	
+	right: 3px;
 	top: 2px;
-	height: 24px;	
+	height: 24px;
 	background-color: #fff;
 	.opacity(30);
-	.rounded-corners(5px);	
+	.rounded-corners(5px);
 }
 
 .dojoxCalendarEvent .resizeHandle div:active {
-	.opacity(60);	
+	.opacity(60);
 }
 
 .dojoxCalendarColumnView .dojoxCalendarEvent .moveHandle {
@@ -323,12 +335,12 @@
 	top:0;
 	width:100%;
 	bottom:0;
-	cursor:move;	
+	cursor:move;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarEvent .resizeStartHandle {
 	position: absolute;
-	top:0;	
+	top:0;
 	left: 0;
 	right: 0;
 	height:30px;
@@ -337,9 +349,9 @@
 
 .dojoxCalendarColumnView .dojoxCalendarEvent .resizeEndHandle {
 	position: absolute;
-	bottom:0;	
+	bottom:0;
 	left: 0;
-	right: 0;	
+	right: 0;
 	height:30px;
 	z-index: 2;
 }
@@ -366,7 +378,7 @@
 	overflow-x: hidden;
 }
 
-.dojoxCalendarColumnView .dojoxCalendarMatrixView {	
+.dojoxCalendarColumnView .dojoxCalendarMatrixView {
 	position: absolute;
 	left: 0;
 	right: 0;
@@ -374,7 +386,7 @@
 	height: @secondary-sheet-height;
 }
 
-.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarGrid {	
+.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarGrid {
 	position: absolute;
 	left: @row-header-width;
 	right: 0;
@@ -383,7 +395,7 @@
 	.border-box;
 }
 
-.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarContainer {	
+.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarContainer {
 	position: absolute;
 	top: 0;
 	left: @row-header-width;
@@ -394,11 +406,11 @@
 
 .dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarRowHeader {
 	position: absolute;
-	left: 0;				
+	left: 0;
 	top: 0;
 	width: @row-header-width;
 	bottom: 0;
-	
+
 	border-right: none;
 	border-left: none;
 	.border-box;
@@ -406,7 +418,7 @@
 
 .dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarGridTable td {
 	text-align: right;
-	vertical-align: top;	
+	vertical-align: top;
 	border-top: @inner-border;
 	border-bottom: @inner-border;
 	border-right: @inner-border;
@@ -448,15 +460,15 @@
 	overflow: hidden;
 }
 
-.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .resizeHandle {	
+.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .resizeHandle {
 	top: auto;
 	text-align: auto;
 	position: absolute;
 	width:30px;
-	height:100%;	
+	height:100%;
 	background-color: #fff;
 	.opacity(0);
-	.rounded-corners(5px);	
+	.rounded-corners(5px);
 	color: #000;
 	text-align: center;
 }
@@ -466,34 +478,34 @@
 	width: auto;
 	height: auto;
 	left:auto;
-	right: auto;	
+	right: auto;
 	top: auto;
-	bottom:auto;		
+	bottom:auto;
 	background-color: none;
 	.opacity(100);
-	border: none;	
+	border: none;
 }
 
 
-.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .resizeStartHandle span {	
+.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .resizeStartHandle span {
 	position: absolute;
 	bottom: 2px;
 	left: 10px;
 }
 
-.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .resizeEndHandle span {	
+.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .resizeEndHandle span {
 	position: absolute;
 	bottom: 2px;
 	left: 10px;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .moveHandle {
-	
+
 	position: absolute;
 	left:0;
 	top:0;
 	bottom:0;
-	right:0;	
+	right:0;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .resizeStartHandle {
@@ -505,7 +517,7 @@
 	left:auto;
 }
 
-.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent.Edited .resizeHandle {		
+.dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent.Edited .resizeHandle {
 	.opacity(30);
 }
 
@@ -514,7 +526,7 @@
 }
 
 .dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarEvent .endTime {
-	position: relative;				
+	position: relative;
 	bottom:auto;
 	left: auto;
 }
@@ -535,7 +547,7 @@
 	-moz-border-radius: 5px;
 	-webkit-transition-duration: 0.2s;
 	-moz-transition-duration: 0.2s;
-	transition-duration: 0.2s;	
+	transition-duration: 0.2s;
 }
 
 .dojoxCalendarColumnView .dojoxCalendarMatrixView .dojoxCalendarExpand.Up .bg {

--- a/themes/nihilo/ColumnView.less
+++ b/themes/nihilo/ColumnView.less
@@ -1,6 +1,6 @@
 @import "ColumnViewCommon.less";
 
-.nihilo .dojoxCalendarColumnView {	
+.nihilo .dojoxCalendarColumnView {
 	cursor: default;
 	-webkit-user-select: none;
 
@@ -25,14 +25,14 @@
 		border-bottom: @outer-border;
 		.border-box;
 	}
-	
+
 	.dojoxCalendarGrid {
 		position: absolute;
 		left: @row-header-width;
 		right: 0;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarGrid.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
@@ -44,13 +44,13 @@
 		position: relative;
 		margin: 0;
 		padding: 0;
-		
+
 	 	td {
-			border-top: dotted 1px @outer-border;	
+			border-top: dotted 1px @outer-border;
 			border-right: @inner-border;
 			.border-box;
 		}
-	
+
 		tr:first-child td	{
 			border-top: 1px solid transparent;
 		}
@@ -58,31 +58,31 @@
 		.dojoxCalendarToday {
 			background-color: @today-color;
 		}
-		
+
 		tr td.last-child	{
 			border-right: @outer-border;
 		}
-		
+
 		.tr:first-child td.dojoxCalendarToday	{
 			border-top: 1px solid @today-color;
 		}
-		
+
 		.dojoxCalendarWeekend {
 			background-color: @week-end-color;
 		}
-		
+
 		tr:first-child td.dojoxCalendarWeekend	{
 			border-top: 1px solid @week-end-color;
-		}	
+		}
 	}
 
-	 
+
 	td.hour {
 		border-top: @hour-stroke;
 	}
 
 	td.halfhour{
-		border-top: @half-hour-stroke;	
+		border-top: @half-hour-stroke;
 	}
 
 	td.quarterhour{
@@ -107,12 +107,24 @@
 		right: 0;
 		cursor: default;
 		overflow: hidden;
+
+		table {
+			background-color: transparent;
+
+			tr {
+				background-color: transparent;
+
+				td {
+					background-color: transparent;
+				}
+			}
+		}
 	}
-	
+
 	.dojoxCalendarContainer.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-	
+
 	.dojoxCalendarContainerTable {
 		border-collapse: collapse;
 		table-layout: fixed;
@@ -120,7 +132,7 @@
 		position: relative;
 		margin: 0;
 		padding: 0;
-	
+
 		td {
 			height: 100%;
 			padding: 0;
@@ -128,39 +140,39 @@
 			border-right: 1px solid transparent;
 		}
 	}
-	
+
 	.dojoxCalendarContainerColumn {
 		position: relative;
-		width:100%;		
+		width:100%;
 	}
-	
+
 	.dojoxCalendarSubContainerColumn {
-		position: absolute;		
+		position: absolute;
 		top: 0;
 		.border-box;
-		height:100%;	
+		height:100%;
 	}
-	
+
 	.dojoxCalendarEventContainerColumn {
-		position: absolute;		
+		position: absolute;
 		height: 100%;
 		left:0;
 		top:0;
 		right:0;
 		margin-left: 1px;
-		margin-right: 5px;		
+		margin-right: 5px;
 	}
-	
+
 	.dojoxCalendarDecorationContainerColumn {
-		position: absolute;		
+		position: absolute;
 		height: 100%;
 		left:0;
 		top:0;
-		right:0;	
+		right:0;
 	}
-	
+
 	.dojoxCalendarSubContainerColumn.subColumn {
-		border-right: @sub-column-border;		
+		border-right: @sub-column-border;
 	}
 
 	.dojoxCalendarEventContainer {
@@ -174,21 +186,21 @@
 		height: @column-header-height - 1px;
 		left: 0;
 		width: @row-header-width - 2px;
-		top: 0;	
+		top: 0;
 		border-left: @outer-border;
 		border-top: @outer-border;
-		border-right: @outer-border;	
-	
+		border-right: @outer-border;
+
 		table {
 			position:relative;
 			width:100%;
-			height:100%;	
+			height:100%;
 		}
-		
+
 		table td {
 			text-align: center;
 			vertical-align: middle;
-			border-bottom: @outer-border;	
+			border-bottom: @outer-border;
 			color: @label-color;
 			.header-background;
 		}
@@ -196,28 +208,28 @@
 
 	.dojoxCalendarColumnHeader {
 		position: absolute;
-		height: @column-header-height;	 
+		height: @column-header-height;
 		left: @row-header-width;
 		right: 0;
 		top: 0;
 		cursor: default;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarColumnHeader.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-	
+
 	.dojoxCalendarColumnHeaderTable {
 		border-collapse: collapse;
 		table-layout: fixed;
 		position: relative;
 		margin: 0;
-		padding: 0;			
+		padding: 0;
 		width: 100%;
-		height: 100%;	
+		height: 100%;
 
-		td {	
+		td {
 			overflow:hidden;
 			white-space: nowrap;
 			vertical-align: middle;
@@ -230,30 +242,30 @@
 			color: @label-color;
 			.transition-duration(0.2s);
 		}
-		
-		td.last-child {	
-			border-right: @outer-border;	
+
+		td.last-child {
+			border-right: @outer-border;
 		}
-		
+
 		.dojoxCalendarToday {
 			font-weight: bold;
 			color: @today-label-color;
 		}
-		
+
 		.dojoxCalendarWeekend {
 			color: @week-end-label-color;
 		}
-		
-		td.Hover{	
-			cursor: pointer;		
+
+		td.Hover{
+			cursor: pointer;
 			.header-hover-background;
 		}
-		
-		td.Active{	
+
+		td.Active{
 			.header-active-background;
 		}
 	}
-	
+
 	.dojoxCalendarSubHeader {
 		position: absolute;
 		left: 0;
@@ -265,7 +277,7 @@
 		box-sizing: border-box;
 		display: none;
 	}
-	
+
 	.dojoxCalendarSubColumnHeader {
 		position: absolute;
 		height: @sub-column-header-height;
@@ -275,11 +287,11 @@
 		cursor: default;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarSubColumnHeader.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-		
+
 	.dojoxCalendarSubColumnHeaderTable {
 		border-collapse: collapse;
 		table-layout: fixed;
@@ -288,55 +300,55 @@
 		padding: 0;
 		width: 100%;
 		height: 100%;
-		
+
 		td {
 			overflow: hidden;
 			white-space: nowrap;
 			vertical-align: middle;
-			text-align: center;  
-			border-right: @inner-border; 
+			text-align: center;
+			border-right: @inner-border;
 			border-top: @outer-border;
 			-moz-user-select: none;
 			-webkit-user-select: none;
 			khtml-user-select: none;
 			user-select: none;
-			color: #000000;  
+			color: #000000;
 		}
 		td.last-child {
 			border-right: @outer-border;
 		}
-		td.dojoxCalendarToday { 
+		td.dojoxCalendarToday {
 			background-color: @today-color;
 		}
 		td.dojoxCalendarWeekend {
 			background-color: @week-end-color;
-		}					
+		}
 	}
-	
-	.dojoxCalendarSubHeaderContainer {			
+
+	.dojoxCalendarSubHeaderContainer {
 		position: relative;
-		width:100%;		
+		width:100%;
 		height: @sub-column-header-height - 2px;
-	}	
-	
+	}
+
 	.dojoxCalendarSubHeaderCell {
-		position: absolute;		
+		position: absolute;
 		top: 0;
 		.border-box;
-		height:100%;	
+		height:100%;
 		overflow: hidden;
 		text-overflow: ellipsis;
-	}	
-	
+	}
+
 	.dojoxCalendarSubHeaderCell.subColumn {
-		border-right: @sub-column-border;		
-	}	
-	
+		border-right: @sub-column-border;
+	}
+
 	.dojoxCalendarSubHeaderLabel {
 		font-size: 0.9em;
 		color: #555;
 	}
-	
+
 	.dojoxCalendarSubRowHeader {
 		position: absolute;
 		height: @sub-column-header-height;
@@ -350,11 +362,11 @@
 			position: relative;
 			width: 100%;
 			height: 100%;
-			
+
 			td {
 				border-top: @outer-border;
-				background-color: #efefef;  
-			}			
+				background-color: #efefef;
+			}
 		}
 	}
 
@@ -374,9 +386,9 @@
 		z-index: 10;
 	}
 
-	.dojoxCalendarRowHeaderLabel{	
-		right: 4px;		
-		position: absolute;	
+	.dojoxCalendarRowHeaderLabel{
+		right: 4px;
+		position: absolute;
 	}
 
 	.dojoxCalendarRowHeaderTable {
@@ -387,35 +399,35 @@
 		padding: 0;
 		width: 100%;
 		height: 100%;
-	
+
 		td.dummy{
 			border-top: 1px solid @row-color;
 		}
-		
+
 		td {
 			background-color: @row-color;
 			color: @label-color;
 			.border-box;
 		}
-		
+
 		tr:first-child td	{
 			border-top: 1px solid @row-color;
 		}
 	}
-	
+
 	.dojoxCalendarDecoration {
 		position:absolute;
 		background-color: rgb(167, 233, 68);
 		.opacity(20);
 	}
- 
+
 	.dojoxCalendarEvent {
-		position: absolute;	
+		position: absolute;
 		text-align: left;
 		color: #FFF;
 		cursor: default;
 		overflow: hidden;
-	
+
 		.bg {
 			position: absolute;
 			left: 0;
@@ -428,10 +440,10 @@
 			background-color: @event-bg-color;
 			.opacity(90);
 		}
-				
+
 		.endTime {
-			position: absolute;		
-			font-weight: bold;	
+			position: absolute;
+			font-weight: bold;
 			bottom:3px;
 			left: 6px;
 			white-space:nowrap;
@@ -457,7 +469,7 @@
 			top:0;
 			width:100%;
 			bottom:0;
-			cursor:move;	
+			cursor:move;
 		}
 
 		.resizeStartHandle {
@@ -465,7 +477,7 @@
 			top:0;
 			width:100%;
 			height:10px;
-			cursor:n-resize;	
+			cursor:n-resize;
 		}
 
 		.resizeEndHandle {
@@ -473,7 +485,7 @@
 			bottom:0;
 			width:100%;
 			height:10px;
-			cursor:n-resize;	
+			cursor:n-resize;
 		}
 
 		dl {
@@ -488,7 +500,7 @@
 	}
 
 	.dojoxCalendarEvent.Hovered .bg {
-		background-color: @event-hovered-bg-color;	
+		background-color: @event-hovered-bg-color;
 	}
 
 	.dojoxCalendarEvent.Selected .bg {
@@ -503,11 +515,11 @@
 	.dojoxCalendarEvent.Focused .bg {
 		border: @event-border-focused;
 	}
-	
+
 	.dojoxCalendarEvent .startTime {
 		.event-header;
-		background-color: @event-header-bg-color;	
-		.top-left-right-border(@event-border);		
+		background-color: @event-header-bg-color;
+		.top-left-right-border(@event-border);
 	}
 
 	.dojoxCalendarEvent.Focused .startTime {
@@ -534,23 +546,23 @@
 		overflow-y: scroll;
 		overflow-x: hidden;
 	}
-	
+
 	.dojoxCalendarHScrollBar {
-		position: absolute;		
+		position: absolute;
 		bottom: 0;
-		left: @row-header-width;		
+		left: @row-header-width;
 		overflow-x: scroll;
 		overflow-y: hidden;
 	}
 
-	.dojoxCalendarMatrixView {	
+	.dojoxCalendarMatrixView {
 		position: absolute;
 		left: 0;
 		right: 0;
 		top: @column-header-height;
-		height: @secondary-sheet-height;		
+		height: @secondary-sheet-height;
 
-		.dojoxCalendarGrid {	
+		.dojoxCalendarGrid {
 			position: absolute;
 			left: @row-header-width;
 			right: 0;
@@ -558,8 +570,8 @@
 			bottom: 0;
 			.border-box;
 		}
-		
-		.dojoxCalendarContainer {	
+
+		.dojoxCalendarContainer {
 			position: absolute;
 			top: 0;
 			left: @row-header-width;
@@ -567,40 +579,40 @@
 			bottom: 0;
 			cursor: default;
 		}
-		
+
 		.dojoxCalendarRowHeader {
 			position: absolute;
-			left: 0;				
+			left: 0;
 			top: 0;
 			width: @row-header-width;
 			bottom: 0;
-			
+
 			border-right: none;
 			border-left: none;
 			.border-box;
 		}
-		
+
 		.dojoxCalendarGridTable{
-			
+
 			td {
 				text-align: right;
-				vertical-align: top;	
+				vertical-align: top;
 				border-top: @inner-border;
 				border-bottom: @inner-border;
 				border-right: @inner-border;
 				.border-box;
 			}
-			
+
 			tr.last-child td	{
 				border-bottom: @outer-border;
 			}
-			
+
 			td.last-child	{
 				border-right: @outer-border;
 			}
-			
+
 		}
-		
+
 		.dojoxCalendarRowHeaderTable td {
 			border-top: @inner-border;
 			border-left: @outer-border;
@@ -608,38 +620,38 @@
 			border-bottom: @outer-border;
 			background-color: @row-color;
 		}
-		
+
 		.dojoxCalendarEvent {
 			.handle {
 				.glass-view;
 				position: absolute;
 				width:5px;
 				height:100%;
-				cursor:e-resize;	
+				cursor:e-resize;
 			}
-			
+
 			.moveHandle {
 				left:0;
 				top:0;
 				width:100%;
-				cursor:move;	
+				cursor:move;
 			}
 
 			.resizeEndHandle {
 				right:0px;
 			}
-			
+
 			.afterIcon {
 				width:auto;
 			}
-			
+
 			.endTime {
-				position: relative;				
+				position: relative;
 				bottom:auto;
 				left: auto;
 			}
 		}
-		
+
 		.dojoxCalendarEvent.dojoxCalendarHorizontal .labels {
 			position: absolute;
 			left: 3px;
@@ -647,11 +659,11 @@
 			bottom: 2px;
 			overflow: hidden;
 		}
-		
+
 		.dojoxCalendarExpand {
 			position: absolute;
 			text-align: center;
-			
+
 			.bg {
 				position: relative;
 				margin-right: 10%;
@@ -663,32 +675,32 @@
 				-moz-border-radius: 5px;
 				-webkit-transition-duration: 0.2s;
 				-moz-transition-duration: 0.2s;
-				transition-duration: 0.2s;			
-			}	
+				transition-duration: 0.2s;
+			}
 		}
-		
+
 		.dojoxCalendarExpand.Up .bg {
 			background-color: @expand-up-color;
 			border: 1px solid @expand-up-color - #555;
 		}
-		
+
 		.dojoxCalendarExpand.Down .bg {
 			background-color: @expand-down-color;
 			border: 1px solid @expand-down-color - #555;
 		}
-		
+
 		.dojoxCalendarEvent div {
 			white-space:nowrap;
 		}
 	}
-	
+
 	.dojoxCalendarTimeIndicator {
 		position: absolute;
 		left:0;
 		height: 2px;
 		width:100%;
-		background-color: red;			
-	}					
+		background-color: red;
+	}
 }
 
 .nihilo .dojoxCalendarColumnView.subColumns {
@@ -698,10 +710,10 @@
 	.dojoxCalendarSubHeader {
 		top: @column-header-height + 3px;
 		display: block;
-	}	
+	}
 	.dojoxCalendarVScrollBar {
 		top: @sheet-top-subcolumns;
-	}	
+	}
 }
 
 .nihilo .dojoxCalendarColumnView.secondarySheet {
@@ -729,4 +741,3 @@
 		top: @sheet-top-subcolumns-secondary-sheet;
 	}
 }
-

--- a/themes/soria/ColumnView.less
+++ b/themes/soria/ColumnView.less
@@ -1,6 +1,6 @@
 @import "ColumnViewCommon.less";
 
-.soria .dojoxCalendarColumnView {	
+.soria .dojoxCalendarColumnView {
 	cursor: default;
 	-webkit-user-select: none;
 
@@ -25,14 +25,14 @@
 		border-bottom: @outer-border;
 		.border-box;
 	}
-	
+
 	.dojoxCalendarGrid {
 		position: absolute;
 		left: @row-header-width;
 		right: 0;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarGrid.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
@@ -44,13 +44,13 @@
 		position: relative;
 		margin: 0;
 		padding: 0;
-		
+
 	 	td {
-			border-top: dotted 1px @outer-border;	
+			border-top: dotted 1px @outer-border;
 			border-right: @inner-border;
 			.border-box;
 		}
-	
+
 		tr:first-child td	{
 			border-top: 1px solid transparent;
 		}
@@ -58,31 +58,31 @@
 		.dojoxCalendarToday {
 			background-color: @today-color;
 		}
-		
+
 		tr td.last-child	{
 			border-right: @outer-border;
 		}
-		
+
 		.tr:first-child td.dojoxCalendarToday	{
 			border-top: 1px solid @today-color;
 		}
-		
+
 		.dojoxCalendarWeekend {
 			background-color: @week-end-color;
 		}
-		
+
 		tr:first-child td.dojoxCalendarWeekend	{
 			border-top: 1px solid @week-end-color;
-		}	
+		}
 	}
 
-	 
+
 	td.hour {
 		border-top: @hour-stroke;
 	}
 
 	td.halfhour{
-		border-top: @half-hour-stroke;	
+		border-top: @half-hour-stroke;
 	}
 
 	td.quarterhour{
@@ -107,12 +107,24 @@
 		right: 0;
 		cursor: default;
 		overflow: hidden;
+
+		table {
+			background-color: transparent;
+
+			tr {
+				background-color: transparent;
+
+				td {
+					background-color: transparent;
+				}
+			}
+		}
 	}
-	
+
 	.dojoxCalendarContainer.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-	
+
 	.dojoxCalendarContainerTable {
 		border-collapse: collapse;
 		table-layout: fixed;
@@ -120,7 +132,7 @@
 		position: relative;
 		margin: 0;
 		padding: 0;
-	
+
 		td {
 			height: 100%;
 			padding: 0;
@@ -128,39 +140,39 @@
 			border-right: 1px solid transparent;
 		}
 	}
-	
+
 	.dojoxCalendarContainerColumn {
 		position: relative;
-		width:100%;		
+		width:100%;
 	}
-	
+
 	.dojoxCalendarSubContainerColumn {
-		position: absolute;		
+		position: absolute;
 		top: 0;
 		.border-box;
-		height:100%;	
+		height:100%;
 	}
-	
+
 	.dojoxCalendarEventContainerColumn {
-		position: absolute;		
+		position: absolute;
 		height: 100%;
 		left:0;
 		top:0;
 		right:0;
 		margin-left: 1px;
-		margin-right: 5px;		
+		margin-right: 5px;
 	}
-	
+
 	.dojoxCalendarDecorationContainerColumn {
-		position: absolute;		
+		position: absolute;
 		height: 100%;
 		left:0;
 		top:0;
-		right:0;	
+		right:0;
 	}
-	
+
 	.dojoxCalendarSubContainerColumn.subColumn {
-		border-right: @sub-column-border;		
+		border-right: @sub-column-border;
 	}
 
 	.dojoxCalendarEventContainer {
@@ -174,21 +186,21 @@
 		height: @column-header-height - 1px;
 		left: 0;
 		width: @row-header-width - 2px;
-		top: 0;	
+		top: 0;
 		border-left: @outer-border;
 		border-top: @outer-border;
-		border-right: @outer-border;	
-	
+		border-right: @outer-border;
+
 		table {
 			position:relative;
 			width:100%;
-			height:100%;	
+			height:100%;
 		}
-		
+
 		table td {
 			text-align: center;
 			vertical-align: middle;
-			border-bottom: @outer-border;	
+			border-bottom: @outer-border;
 			color: @label-color;
 			.header-background;
 		}
@@ -196,28 +208,28 @@
 
 	.dojoxCalendarColumnHeader {
 		position: absolute;
-		height: @column-header-height;	 
+		height: @column-header-height;
 		left: @row-header-width;
 		right: 0;
 		top: 0;
 		cursor: default;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarColumnHeader.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-	
+
 	.dojoxCalendarColumnHeaderTable {
 		border-collapse: collapse;
 		table-layout: fixed;
 		position: relative;
 		margin: 0;
-		padding: 0;			
+		padding: 0;
 		width: 100%;
-		height: 100%;	
+		height: 100%;
 
-		td {	
+		td {
 			overflow:hidden;
 			white-space: nowrap;
 			vertical-align: middle;
@@ -230,30 +242,30 @@
 			color: @label-color;
 			.transition-duration(0.2s);
 		}
-		
-		td.last-child {	
-			border-right: @outer-border;	
+
+		td.last-child {
+			border-right: @outer-border;
 		}
-		
+
 		.dojoxCalendarToday {
 			font-weight: bold;
 			color: @today-label-color;
 		}
-		
+
 		.dojoxCalendarWeekend {
 			color: @week-end-label-color;
 		}
-		
-		td.Hover{	
-			cursor: pointer;		
+
+		td.Hover{
+			cursor: pointer;
 			.header-hover-background;
 		}
-		
-		td.Active{	
+
+		td.Active{
 			.header-active-background;
 		}
 	}
-	
+
 	.dojoxCalendarSubHeader {
 		position: absolute;
 		left: 0;
@@ -265,7 +277,7 @@
 		box-sizing: border-box;
 		display: none;
 	}
-	
+
 	.dojoxCalendarSubColumnHeader {
 		position: absolute;
 		height: @sub-column-header-height;
@@ -275,11 +287,11 @@
 		cursor: default;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarSubColumnHeader.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-		
+
 	.dojoxCalendarSubColumnHeaderTable {
 		border-collapse: collapse;
 		table-layout: fixed;
@@ -288,55 +300,55 @@
 		padding: 0;
 		width: 100%;
 		height: 100%;
-		
+
 		td {
 			overflow: hidden;
 			white-space: nowrap;
 			vertical-align: middle;
-			text-align: center;  
-			border-right: @inner-border; 
+			text-align: center;
+			border-right: @inner-border;
 			border-top: @outer-border;
 			-moz-user-select: none;
 			-webkit-user-select: none;
 			khtml-user-select: none;
 			user-select: none;
-			color: #000000;  
+			color: #000000;
 		}
 		td.last-child {
 			border-right: @outer-border;
 		}
-		td.dojoxCalendarToday { 
+		td.dojoxCalendarToday {
 			background-color: @today-color;
 		}
 		td.dojoxCalendarWeekend {
 			background-color: @week-end-color;
-		}					
+		}
 	}
-	
-	.dojoxCalendarSubHeaderContainer {			
+
+	.dojoxCalendarSubHeaderContainer {
 		position: relative;
-		width:100%;		
+		width:100%;
 		height: @sub-column-header-height - 2px;
-	}	
-	
+	}
+
 	.dojoxCalendarSubHeaderCell {
-		position: absolute;		
+		position: absolute;
 		top: 0;
 		.border-box;
-		height:100%;	
+		height:100%;
 		overflow: hidden;
 		text-overflow: ellipsis;
-	}	
-	
+	}
+
 	.dojoxCalendarSubHeaderCell.subColumn {
-		border-right: @sub-column-border;		
-	}	
-	
+		border-right: @sub-column-border;
+	}
+
 	.dojoxCalendarSubHeaderLabel {
 		font-size: 0.9em;
 		color: #555;
 	}
-	
+
 	.dojoxCalendarSubRowHeader {
 		position: absolute;
 		height: @sub-column-header-height;
@@ -350,11 +362,11 @@
 			position: relative;
 			width: 100%;
 			height: 100%;
-			
+
 			td {
 				border-top: @outer-border;
-				background-color: #efefef;  
-			}			
+				background-color: #efefef;
+			}
 		}
 	}
 
@@ -374,9 +386,9 @@
 		z-index: 10;
 	}
 
-	.dojoxCalendarRowHeaderLabel{	
-		right: 4px;		
-		position: absolute;	
+	.dojoxCalendarRowHeaderLabel{
+		right: 4px;
+		position: absolute;
 	}
 
 	.dojoxCalendarRowHeaderTable {
@@ -387,35 +399,35 @@
 		padding: 0;
 		width: 100%;
 		height: 100%;
-	
+
 		td.dummy{
 			border-top: 1px solid @row-color;
 		}
-		
+
 		td {
 			background-color: @row-color;
 			color: @label-color;
 			.border-box;
 		}
-		
+
 		tr:first-child td	{
 			border-top: 1px solid @row-color;
 		}
 	}
-	
+
 	.dojoxCalendarDecoration {
 		position:absolute;
 		background-color: rgb(167, 233, 68);
 		.opacity(20);
 	}
- 
+
 	.dojoxCalendarEvent {
-		position: absolute;	
+		position: absolute;
 		text-align: left;
 		color: #FFF;
 		cursor: default;
 		overflow: hidden;
-	
+
 		.bg {
 			position: absolute;
 			left: 0;
@@ -428,10 +440,10 @@
 			background-color: @event-bg-color;
 			.opacity(90);
 		}
-				
+
 		.endTime {
-			position: absolute;		
-			font-weight: bold;	
+			position: absolute;
+			font-weight: bold;
 			bottom:3px;
 			left: 6px;
 			white-space:nowrap;
@@ -457,7 +469,7 @@
 			top:0;
 			width:100%;
 			bottom:0;
-			cursor:move;	
+			cursor:move;
 		}
 
 		.resizeStartHandle {
@@ -465,7 +477,7 @@
 			top:0;
 			width:100%;
 			height:10px;
-			cursor:n-resize;	
+			cursor:n-resize;
 		}
 
 		.resizeEndHandle {
@@ -473,7 +485,7 @@
 			bottom:0;
 			width:100%;
 			height:10px;
-			cursor:n-resize;	
+			cursor:n-resize;
 		}
 
 		dl {
@@ -488,7 +500,7 @@
 	}
 
 	.dojoxCalendarEvent.Hovered .bg {
-		background-color: @event-hovered-bg-color;	
+		background-color: @event-hovered-bg-color;
 	}
 
 	.dojoxCalendarEvent.Selected .bg {
@@ -503,10 +515,10 @@
 	.dojoxCalendarEvent.Focused .bg {
 		border: @event-border-focused;
 	}
-	
+
 	.dojoxCalendarEvent .startTime {
-		.event-header;	
-		background-color: @event-header-bg-color;	
+		.event-header;
+		background-color: @event-header-bg-color;
 		.top-left-right-border(@event-border);
 	}
 
@@ -534,23 +546,23 @@
 		overflow-y: scroll;
 		overflow-x: hidden;
 	}
-	
+
 	.dojoxCalendarHScrollBar {
-		position: absolute;		
+		position: absolute;
 		bottom: 0;
-		left: @row-header-width;		
+		left: @row-header-width;
 		overflow-x: scroll;
 		overflow-y: hidden;
 	}
 
-	.dojoxCalendarMatrixView {	
+	.dojoxCalendarMatrixView {
 		position: absolute;
 		left: 0;
 		right: 0;
 		top: @column-header-height;
-		height: @secondary-sheet-height;		
+		height: @secondary-sheet-height;
 
-		.dojoxCalendarGrid {	
+		.dojoxCalendarGrid {
 			position: absolute;
 			left: @row-header-width;
 			right: 0;
@@ -558,8 +570,8 @@
 			bottom: 0;
 			.border-box;
 		}
-		
-		.dojoxCalendarContainer {	
+
+		.dojoxCalendarContainer {
 			position: absolute;
 			top: 0;
 			left: @row-header-width;
@@ -567,40 +579,40 @@
 			bottom: 0;
 			cursor: default;
 		}
-		
+
 		.dojoxCalendarRowHeader {
 			position: absolute;
-			left: 0;				
+			left: 0;
 			top: 0;
 			width: @row-header-width;
 			bottom: 0;
-			
+
 			border-right: none;
 			border-left: none;
 			.border-box;
 		}
-		
+
 		.dojoxCalendarGridTable{
-			
+
 			td {
 				text-align: right;
-				vertical-align: top;	
+				vertical-align: top;
 				border-top: @inner-border;
 				border-bottom: @inner-border;
 				border-right: @inner-border;
 				.border-box;
 			}
-			
+
 			tr.last-child td	{
 				border-bottom: @outer-border;
 			}
-			
+
 			td.last-child	{
 				border-right: @outer-border;
 			}
-			
+
 		}
-		
+
 		.dojoxCalendarRowHeaderTable td {
 			border-top: @inner-border;
 			border-left: @outer-border;
@@ -608,38 +620,38 @@
 			border-bottom: @outer-border;
 			background-color: @row-color;
 		}
-		
+
 		.dojoxCalendarEvent {
 			.handle {
 				.glass-view;
 				position: absolute;
 				width:5px;
 				height:100%;
-				cursor:e-resize;	
+				cursor:e-resize;
 			}
-			
+
 			.moveHandle {
 				left:0;
 				top:0;
 				width:100%;
-				cursor:move;	
+				cursor:move;
 			}
 
 			.resizeEndHandle {
 				right:0px;
 			}
-			
+
 			.afterIcon {
 				width:auto;
 			}
-			
+
 			.endTime {
-				position: relative;				
+				position: relative;
 				bottom:auto;
 				left: auto;
 			}
 		}
-		
+
 		.dojoxCalendarEvent.dojoxCalendarHorizontal .labels {
 			position: absolute;
 			left: 3px;
@@ -647,11 +659,11 @@
 			bottom: 2px;
 			overflow: hidden;
 		}
-		
+
 		.dojoxCalendarExpand {
 			position: absolute;
 			text-align: center;
-			
+
 			.bg {
 				position: relative;
 				margin-right: 10%;
@@ -663,32 +675,32 @@
 				-moz-border-radius: 5px;
 				-webkit-transition-duration: 0.2s;
 				-moz-transition-duration: 0.2s;
-				transition-duration: 0.2s;			
-			}	
+				transition-duration: 0.2s;
+			}
 		}
-		
+
 		.dojoxCalendarExpand.Up .bg {
 			background-color: @expand-up-color;
 			border: 1px solid @expand-up-color - #555;
 		}
-		
+
 		.dojoxCalendarExpand.Down .bg {
 			background-color: @expand-down-color;
 			border: 1px solid @expand-down-color - #555;
 		}
-		
+
 		.dojoxCalendarEvent div {
 			white-space:nowrap;
 		}
 	}
-	
+
 	.dojoxCalendarTimeIndicator {
 		position: absolute;
 		left:0;
 		height: 2px;
 		width:100%;
-		background-color: red;			
-	}					
+		background-color: red;
+	}
 }
 
 .soria .dojoxCalendarColumnView.subColumns {
@@ -701,8 +713,8 @@
 	}
 	.dojoxCalendarVScrollBar {
 		top: @sheet-top-subcolumns;
-	}	
-		
+	}
+
 }
 
 .soria .dojoxCalendarColumnView.secondarySheet {
@@ -730,4 +742,3 @@
 		top: @sheet-top-subcolumns-secondary-sheet;
 	}
 }
-

--- a/themes/tundra/ColumnView.less
+++ b/themes/tundra/ColumnView.less
@@ -1,6 +1,6 @@
 @import "ColumnViewCommon.less";
 
-.tundra .dojoxCalendarColumnView {	
+.tundra .dojoxCalendarColumnView {
 	cursor: default;
 	-webkit-user-select: none;
 
@@ -25,14 +25,14 @@
 		border-bottom: @outer-border;
 		.border-box;
 	}
-	
+
 	.dojoxCalendarGrid {
 		position: absolute;
 		left: @row-header-width;
 		right: 0;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarGrid.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
@@ -44,13 +44,13 @@
 		position: relative;
 		margin: 0;
 		padding: 0;
-		
+
 	 	td {
-			border-top: dotted 1px @outer-border;	
+			border-top: dotted 1px @outer-border;
 			border-right: @inner-border;
 			.border-box;
 		}
-	
+
 		tr:first-child td	{
 			border-top: 1px solid transparent;
 		}
@@ -58,31 +58,31 @@
 		.dojoxCalendarToday {
 			background-color: @today-color;
 		}
-		
+
 		tr td.last-child	{
 			border-right: @outer-border;
 		}
-		
+
 		.tr:first-child td.dojoxCalendarToday	{
 			border-top: 1px solid @today-color;
 		}
-		
+
 		.dojoxCalendarWeekend {
 			background-color: @week-end-color;
 		}
-		
+
 		tr:first-child td.dojoxCalendarWeekend	{
 			border-top: 1px solid @week-end-color;
-		}	
+		}
 	}
 
-	 
+
 	td.hour {
 		border-top: @hour-stroke;
 	}
 
 	td.halfhour{
-		border-top: @half-hour-stroke;	
+		border-top: @half-hour-stroke;
 	}
 
 	td.quarterhour{
@@ -107,12 +107,24 @@
 		right: 0;
 		cursor: default;
 		overflow: hidden;
+
+		table {
+			background-color: transparent;
+
+			tr {
+				background-color: transparent;
+
+				td {
+					background-color: transparent;
+				}
+			}
+		}
 	}
-	
+
 	.dojoxCalendarContainer.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-	
+
 	.dojoxCalendarContainerTable {
 		border-collapse: collapse;
 		table-layout: fixed;
@@ -120,7 +132,7 @@
 		position: relative;
 		margin: 0;
 		padding: 0;
-	
+
 		td {
 			height: 100%;
 			padding: 0;
@@ -128,39 +140,39 @@
 			border-right: 1px solid transparent;
 		}
 	}
-	
+
 	.dojoxCalendarContainerColumn {
 		position: relative;
-		width:100%;		
+		width:100%;
 	}
-	
+
 	.dojoxCalendarSubContainerColumn {
-		position: absolute;		
+		position: absolute;
 		top: 0;
 		.border-box;
-		height:100%;	
+		height:100%;
 	}
-	
+
 	.dojoxCalendarEventContainerColumn {
-		position: absolute;		
+		position: absolute;
 		height: 100%;
 		left:0;
 		top:0;
 		right:0;
 		margin-left: 1px;
-		margin-right: 5px;		
+		margin-right: 5px;
 	}
-	
+
 	.dojoxCalendarDecorationContainerColumn {
-		position: absolute;		
+		position: absolute;
 		height: 100%;
 		left:0;
 		top:0;
-		right:0;	
+		right:0;
 	}
-	
+
 	.dojoxCalendarSubContainerColumn.subColumn {
-		border-right: @sub-column-border;		
+		border-right: @sub-column-border;
 	}
 
 	.dojoxCalendarEventContainer {
@@ -174,21 +186,21 @@
 		height: @column-header-height - 1px;
 		left: 0;
 		width: @row-header-width - 2px;
-		top: 0;	
+		top: 0;
 		border-left: @outer-border;
 		border-top: @outer-border;
-		border-right: @outer-border;	
-	
+		border-right: @outer-border;
+
 		table {
 			position:relative;
 			width:100%;
-			height:100%;	
+			height:100%;
 		}
-		
+
 		table td {
 			text-align: center;
 			vertical-align: middle;
-			border-bottom: @outer-border;	
+			border-bottom: @outer-border;
 			color: @label-color;
 			.header-background;
 		}
@@ -196,28 +208,28 @@
 
 	.dojoxCalendarColumnHeader {
 		position: absolute;
-		height: @column-header-height;	 
+		height: @column-header-height;
 		left: @row-header-width;
 		right: 0;
 		top: 0;
 		cursor: default;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarColumnHeader.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-	
+
 	.dojoxCalendarColumnHeaderTable {
 		border-collapse: collapse;
 		table-layout: fixed;
 		position: relative;
 		margin: 0;
-		padding: 0;			
+		padding: 0;
 		width: 100%;
-		height: 100%;	
+		height: 100%;
 
-		td {	
+		td {
 			overflow:hidden;
 			white-space: nowrap;
 			vertical-align: middle;
@@ -230,30 +242,30 @@
 			color: @label-color;
 			.transition-duration(0.2s);
 		}
-		
-		td.last-child {	
-			border-right: @outer-border;	
+
+		td.last-child {
+			border-right: @outer-border;
 		}
-		
+
 		.dojoxCalendarToday {
 			font-weight: bold;
 			color: @today-label-color;
 		}
-		
+
 		.dojoxCalendarWeekend {
 			color: @week-end-label-color;
 		}
-		
-		td.Hover{	
-			cursor: pointer;		
+
+		td.Hover{
+			cursor: pointer;
 			.header-hover-background;
 		}
-		
-		td.Active{	
+
+		td.Active{
 			.header-active-background;
 		}
 	}
-	
+
 	.dojoxCalendarSubHeader {
 		position: absolute;
 		left: 0;
@@ -265,7 +277,7 @@
 		box-sizing: border-box;
 		display: none;
 	}
-	
+
 	.dojoxCalendarSubColumnHeader {
 		position: absolute;
 		height: @sub-column-header-height;
@@ -275,11 +287,11 @@
 		cursor: default;
 		overflow: hidden;
 	}
-	
+
 	.dojoxCalendarSubColumnHeader.dojoxCalendarHorizontalScroll {
 		border-right: @outer-border;
 	}
-		
+
 	.dojoxCalendarSubColumnHeaderTable {
 		border-collapse: collapse;
 		table-layout: fixed;
@@ -288,55 +300,55 @@
 		padding: 0;
 		width: 100%;
 		height: 100%;
-		
+
 		td {
 			overflow: hidden;
 			white-space: nowrap;
 			vertical-align: middle;
-			text-align: center;  
-			border-right: @inner-border; 
+			text-align: center;
+			border-right: @inner-border;
 			border-top: @outer-border;
 			-moz-user-select: none;
 			-webkit-user-select: none;
 			khtml-user-select: none;
 			user-select: none;
-			color: #000000;  
+			color: #000000;
 		}
 		td.last-child {
 			border-right: @outer-border;
 		}
-		td.dojoxCalendarToday { 
+		td.dojoxCalendarToday {
 			background-color: @today-color;
 		}
 		td.dojoxCalendarWeekend {
 			background-color: @week-end-color;
-		}					
+		}
 	}
-	
-	.dojoxCalendarSubHeaderContainer {			
+
+	.dojoxCalendarSubHeaderContainer {
 		position: relative;
-		width:100%;		
+		width:100%;
 		height: @sub-column-header-height - 2px;
-	}	
-	
+	}
+
 	.dojoxCalendarSubHeaderCell {
-		position: absolute;		
+		position: absolute;
 		top: 0;
 		.border-box;
-		height:100%;	
+		height:100%;
 		overflow: hidden;
 		text-overflow: ellipsis;
-	}	
-	
+	}
+
 	.dojoxCalendarSubHeaderCell.subColumn {
-		border-right: @sub-column-border;		
-	}	
-	
+		border-right: @sub-column-border;
+	}
+
 	.dojoxCalendarSubHeaderLabel {
 		font-size: 0.9em;
 		color: #555;
 	}
-	
+
 	.dojoxCalendarSubRowHeader {
 		position: absolute;
 		height: @sub-column-header-height;
@@ -350,11 +362,11 @@
 			position: relative;
 			width: 100%;
 			height: 100%;
-			
+
 			td {
 				border-top: @outer-border;
-				background-color: #efefef;  
-			}			
+				background-color: #efefef;
+			}
 		}
 	}
 
@@ -374,9 +386,9 @@
 		z-index: 10;
 	}
 
-	.dojoxCalendarRowHeaderLabel{	
-		right: 4px;		
-		position: absolute;	
+	.dojoxCalendarRowHeaderLabel{
+		right: 4px;
+		position: absolute;
 	}
 
 	.dojoxCalendarRowHeaderTable {
@@ -387,35 +399,35 @@
 		padding: 0;
 		width: 100%;
 		height: 100%;
-	
+
 		td.dummy{
 			border-top: 1px solid @row-color;
 		}
-		
+
 		td {
 			background-color: @row-color;
 			color: @label-color;
 			.border-box;
 		}
-		
+
 		tr:first-child td	{
 			border-top: 1px solid @row-color;
 		}
 	}
-	
+
 	.dojoxCalendarDecoration {
 		position:absolute;
 		background-color: rgb(167, 233, 68);
 		.opacity(20);
 	}
- 
+
 	.dojoxCalendarEvent {
-		position: absolute;	
+		position: absolute;
 		text-align: left;
 		color: #FFF;
 		cursor: default;
 		overflow: hidden;
-	
+
 		.bg {
 			position: absolute;
 			left: 0;
@@ -428,10 +440,10 @@
 			background-color: @event-bg-color;
 			.opacity(90);
 		}
-				
+
 		.endTime {
-			position: absolute;		
-			font-weight: bold;	
+			position: absolute;
+			font-weight: bold;
 			bottom:3px;
 			left: 6px;
 			white-space:nowrap;
@@ -457,7 +469,7 @@
 			top:0;
 			width:100%;
 			bottom:0;
-			cursor:move;	
+			cursor:move;
 		}
 
 		.resizeStartHandle {
@@ -465,7 +477,7 @@
 			top:0;
 			width:100%;
 			height:10px;
-			cursor:n-resize;	
+			cursor:n-resize;
 		}
 
 		.resizeEndHandle {
@@ -473,7 +485,7 @@
 			bottom:0;
 			width:100%;
 			height:10px;
-			cursor:n-resize;	
+			cursor:n-resize;
 		}
 
 		dl {
@@ -488,7 +500,7 @@
 	}
 
 	.dojoxCalendarEvent.Hovered .bg {
-		background-color: @event-hovered-bg-color;	
+		background-color: @event-hovered-bg-color;
 	}
 
 	.dojoxCalendarEvent.Selected .bg {
@@ -503,10 +515,10 @@
 	.dojoxCalendarEvent.Focused .bg {
 		border: @event-border-focused;
 	}
-	
+
 	.dojoxCalendarEvent .startTime {
-		.event-header;	
-		background-color: @event-header-bg-color;	
+		.event-header;
+		background-color: @event-header-bg-color;
 		.top-left-right-border(@event-border);
 	}
 
@@ -534,23 +546,23 @@
 		overflow-y: scroll;
 		overflow-x: hidden;
 	}
-	
+
 	.dojoxCalendarHScrollBar {
-		position: absolute;		
+		position: absolute;
 		bottom: 0;
-		left: @row-header-width;		
+		left: @row-header-width;
 		overflow-x: scroll;
 		overflow-y: hidden;
 	}
 
-	.dojoxCalendarMatrixView {	
+	.dojoxCalendarMatrixView {
 		position: absolute;
 		left: 0;
 		right: 0;
 		top: @column-header-height;
-		height: @secondary-sheet-height;		
+		height: @secondary-sheet-height;
 
-		.dojoxCalendarGrid {	
+		.dojoxCalendarGrid {
 			position: absolute;
 			left: @row-header-width;
 			right: 0;
@@ -558,8 +570,8 @@
 			bottom: 0;
 			.border-box;
 		}
-		
-		.dojoxCalendarContainer {	
+
+		.dojoxCalendarContainer {
 			position: absolute;
 			top: 0;
 			left: @row-header-width;
@@ -567,40 +579,40 @@
 			bottom: 0;
 			cursor: default;
 		}
-		
+
 		.dojoxCalendarRowHeader {
 			position: absolute;
-			left: 0;				
+			left: 0;
 			top: 0;
 			width: @row-header-width;
 			bottom: 0;
-			
+
 			border-right: none;
 			border-left: none;
 			.border-box;
 		}
-		
+
 		.dojoxCalendarGridTable{
-			
+
 			td {
 				text-align: right;
-				vertical-align: top;	
+				vertical-align: top;
 				border-top: @inner-border;
 				border-bottom: @inner-border;
 				border-right: @inner-border;
 				.border-box;
 			}
-			
+
 			tr.last-child td	{
 				border-bottom: @outer-border;
 			}
-			
+
 			td.last-child	{
 				border-right: @outer-border;
 			}
-			
+
 		}
-		
+
 		.dojoxCalendarRowHeaderTable td {
 			border-top: @inner-border;
 			border-left: @outer-border;
@@ -608,38 +620,38 @@
 			border-bottom: @outer-border;
 			background-color: @row-color;
 		}
-		
+
 		.dojoxCalendarEvent {
 			.handle {
 				.glass-view;
 				position: absolute;
 				width:5px;
 				height:100%;
-				cursor:e-resize;	
+				cursor:e-resize;
 			}
-			
+
 			.moveHandle {
 				left:0;
 				top:0;
 				width:100%;
-				cursor:move;	
+				cursor:move;
 			}
 
 			.resizeEndHandle {
 				right:0px;
 			}
-			
+
 			.afterIcon {
 				width:auto;
 			}
-			
+
 			.endTime {
-				position: relative;				
+				position: relative;
 				bottom:auto;
 				left: auto;
 			}
 		}
-		
+
 		.dojoxCalendarEvent.dojoxCalendarHorizontal .labels {
 			position: absolute;
 			left: 3px;
@@ -647,11 +659,11 @@
 			bottom: 2px;
 			overflow: hidden;
 		}
-		
+
 		.dojoxCalendarExpand {
 			position: absolute;
 			text-align: center;
-			
+
 			.bg {
 				position: relative;
 				margin-right: 10%;
@@ -663,32 +675,32 @@
 				-moz-border-radius: 5px;
 				-webkit-transition-duration: 0.2s;
 				-moz-transition-duration: 0.2s;
-				transition-duration: 0.2s;			
-			}	
+				transition-duration: 0.2s;
+			}
 		}
-		
+
 		.dojoxCalendarExpand.Up .bg {
 			background-color: @expand-up-color;
 			border: 1px solid @expand-up-color - #555;
 		}
-		
+
 		.dojoxCalendarExpand.Down .bg {
 			background-color: @expand-down-color;
 			border: 1px solid @expand-down-color - #555;
 		}
-		
+
 		.dojoxCalendarEvent div {
 			white-space:nowrap;
 		}
 	}
-	
+
 	.dojoxCalendarTimeIndicator {
 		position: absolute;
 		left:0;
 		height: 2px;
 		width:100%;
-		background-color: red;			
-	}					
+		background-color: red;
+	}
 }
 
 .tundra .dojoxCalendarColumnView.subColumns {
@@ -698,7 +710,7 @@
 	.dojoxCalendarSubHeader {
 		top: @column-header-height + 3px;
 		display: block;
-	}	
+	}
 	.dojoxCalendarVScrollBar {
 		top: @sheet-top-subcolumns;
 	}
@@ -729,4 +741,3 @@
 		top: @sheet-top-subcolumns-secondary-sheet;
 	}
 }
-


### PR DESCRIPTION
See https://bugs.dojotoolkit.org/ticket/18685 . Looks like my editor also went to town stripping the trailing whitespace.

I did not commit compiled .css files, I assume you can handle that if this is the right approach.