### PR TITLE
Google Closure Compiler upgrade: Removing duplicate object keys and function arguments

### DIFF
--- a/CalendarBase.js
+++ b/CalendarBase.js
@@ -281,8 +281,6 @@ _nls){
 
 		_currentViewIndex: -1,
 
-		views: null,
-
 		_calendar: "gregorian",
 
 		constructor: function(/*Object*/args){
@@ -1176,14 +1174,6 @@ _nls){
 				fadeFunc({node: node, duration: this.animationRangeDuration/2})
 			]).play();
 		},
-
-		// _animRangeOutDir: Boolean
-		//		Direction of the range animation when the view 'leaving' the screen.
-		//		Valid values are:
-		//		- null: auto value,
-		//		- "left": hides to left side (right in right to left).
-		//		- "right": hides to right side (left in right to left).
-		_animRangeOutDir: null,
 
 		// _animRangeInDir: Boolean
 		//		Direction of the range animation when the view 'entering' the screen.

--- a/ColumnView.js
+++ b/ColumnView.js
@@ -219,7 +219,7 @@ function(
 			}
 		},
 
-		_getHorizontalRendererAttr: function(){
+		_getHorizontalDecorationRendererAttr: function(){
 			if(this.secondarySheet){
 				return this.secondarySheet.get("horizontalDecorationRenderer");
 			}

--- a/MonthColumnView.js
+++ b/MonthColumnView.js
@@ -123,10 +123,6 @@ function(
 		//		Length of the column labels. Valid values are "wide" or "abbr".
 		columnHeaderFormatLength: null,
 
-		// gridCellDatePattern: String
-		//		The date pattern of the cell labels. By default a custom function is used to compute the label.
-		gridCellDatePattern: null,
-
 		// roundToDay: [private] Boolean
 		roundToDay: true,
 

--- a/ViewBase.js
+++ b/ViewBase.js
@@ -164,10 +164,6 @@ define([
 		// The listeners added by the view itself.
 		_viewHandles: null,
 
-		// doubleTapDelay: Integer
-		//		The maximum time amount in milliseconds between to touchstart events that trigger a double-tap event.
-		doubleTapDelay: 300,
-
 		constructor: function(/*Object*/ args){
 			args = args || {};
 

--- a/tests/unitTest_Time.js
+++ b/tests/unitTest_Time.js
@@ -1,5 +1,5 @@
-define(["doh", "../time", "dojo/date", "dojo/date/locale", "dojox/date/hebrew/Date", "dojox/date/hebrew", "dojox/date/hebrew/locale", "dojox/calendar/time"],
-	function(doh, time, date, dateLocale, hDate, h, hLocale, time){
+define(["doh", "../time", "dojo/date", "dojo/date/locale", "dojox/date/hebrew/Date", "dojox/date/hebrew", "dojox/date/hebrew/locale"],
+	function(doh, time, date, dateLocale, hDate, h, hLocale){
 	doh.register("tests.unitTest_Time", [
 		function test_decodeDate(doh){
 			var d = new Date(2009, 2, 20, 5, 27, 30, 0);


### PR DESCRIPTION
Dojo 1.x uses currently the Google Closure Compiler v20160911.

It is currently impossible to upgrade the Google Closure Compiler to a newer version. The reason is — there are incompatibility issues, when using the Google Closure Compiler to process Dojo applications: duplicate object keys and duplicate function arguments.

This pull request introduces changes to the Dojox Calendar's source code that remove all the occurrences of duplicate object keys and duplicate function arguments in code.